### PR TITLE
Do not include a newline in the include command

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -14,7 +14,7 @@ const args = minimist(process.argv, {
 })
 
 if (args.include) {
-  console.log(dev.include)
+  process.stdout.write(dev.include)
 }
 
 if (args.require) {


### PR DESCRIPTION
Messes up subsequent includes since the newline is a separator.