### PR TITLE
Replace which dependency with bare-which

### DIFF
--- a/lib/android/shared/adb.js
+++ b/lib/android/shared/adb.js
@@ -1,6 +1,6 @@
 const path = require('path')
 const os = require('os')
-const which = require('which')
+const which = require('bare-which')
 const exec = require('../../shared/exec')
 const spawn = require('../../shared/spawn')
 const sdk = require('../shared/sdk')

--- a/lib/android/shared/apkanalyzer.js
+++ b/lib/android/shared/apkanalyzer.js
@@ -1,5 +1,5 @@
 const path = require('path')
-const which = require('which')
+const which = require('bare-which')
 const exec = require('../../shared/exec')
 const sdk = require('../shared/sdk')
 

--- a/lib/android/shared/avd.js
+++ b/lib/android/shared/avd.js
@@ -1,6 +1,6 @@
 const os = require('os')
 const path = require('path')
-const which = require('which')
+const which = require('bare-which')
 const exec = require('../../shared/exec')
 const sdk = require('../shared/sdk')
 

--- a/lib/android/shared/emulator.js
+++ b/lib/android/shared/emulator.js
@@ -1,6 +1,6 @@
 const path = require('path')
 const os = require('os')
-const which = require('which')
+const which = require('bare-which')
 const exec = require('../../shared/exec')
 const spawn = require('../../shared/spawn')
 const sdk = require('../shared/sdk')

--- a/lib/android/shared/sdk.js
+++ b/lib/android/shared/sdk.js
@@ -1,7 +1,7 @@
 const process = require('process')
 const path = require('path')
 const os = require('os')
-const which = require('which')
+const which = require('bare-which')
 const exec = require('../../shared/exec')
 
 exports.path = process.env.ANDROID_HOME || path.join(os.homedir(), '.android/sdk')

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -1,6 +1,6 @@
 const os = require('os')
 const path = require('path')
-const which = require('which')
+const which = require('bare-which')
 const spawn = require('./shared/spawn')
 const cmake = require('./shared/cmake')
 const paths = require('./paths')

--- a/lib/ios/shared/simctl.js
+++ b/lib/ios/shared/simctl.js
@@ -1,5 +1,5 @@
 const path = require('path')
-const which = require('which')
+const which = require('bare-which')
 const exec = require('../../shared/exec')
 const spawn = require('../../shared/spawn')
 const xcrun = require('./xcrun')

--- a/lib/ios/shared/xcrun.js
+++ b/lib/ios/shared/xcrun.js
@@ -1,4 +1,4 @@
-const which = require('which')
+const which = require('bare-which')
 const exec = require('../../shared/exec')
 
 const xcrun = module.exports = exports = function xcrun () {

--- a/lib/shared/cmake.js
+++ b/lib/shared/cmake.js
@@ -1,5 +1,5 @@
 const path = require('path')
-const which = require('which')
+const which = require('bare-which')
 
 module.exports = exports = function cmake () {
   return which.sync('cmake')

--- a/lib/shared/git.js
+++ b/lib/shared/git.js
@@ -1,4 +1,4 @@
-const which = require('which')
+const which = require('bare-which')
 
 module.exports = function git () {
   return which.sync('git')

--- a/lib/shared/gradle.js
+++ b/lib/shared/gradle.js
@@ -1,4 +1,4 @@
-const which = require('which')
+const which = require('bare-which')
 
 module.exports = function gradle () {
   return which.sync('gradle')

--- a/lib/vendor/checkout.js
+++ b/lib/vendor/checkout.js
@@ -1,5 +1,5 @@
 const path = require('path')
-const which = require('which')
+const which = require('bare-which')
 const spawn = require('../shared/spawn')
 const sync = require('./sync')
 

--- a/lib/vendor/clean.js
+++ b/lib/vendor/clean.js
@@ -1,5 +1,5 @@
 const path = require('path')
-const which = require('which')
+const which = require('bare-which')
 const spawn = require('../shared/spawn')
 
 const git = which.sync('git')

--- a/lib/vendor/sync.js
+++ b/lib/vendor/sync.js
@@ -1,5 +1,5 @@
 const path = require('path')
-const which = require('which')
+const which = require('bare-which')
 const spawn = require('../shared/spawn')
 
 const git = which.sync('git')

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "bare-path": "^2.1.0",
     "bare-process": "^1.2.1",
     "bare-subprocess": "^2.0.3",
+    "bare-which": "^1.0.0",
     "commander": "^11.1.0",
     "compact-encoding": "^2.13.0",
     "corestore": "^6.4.3",
@@ -89,8 +90,7 @@
     "hyperswarm": "^4.3.7",
     "include-static": "^1.1.0",
     "localdrive": "^1.11.0",
-    "unix-path-resolve": "^1.0.2",
-    "which": "^4.0.0"
+    "unix-path-resolve": "^1.0.2"
   },
   "devDependencies": {
     "standard": "^17.0.0"


### PR DESCRIPTION
Right now, importing bare-dev in Bare-based projects causes an error due to the `which` dependency requiring various node packages. 

Even with aliases applied, the `isexe` dependency of `which` [uses functions](https://github.com/isaacs/isexe/blob/626e837aab877acefe9c8d47bed677cc416898c7/src/posix.ts#L52-L54) that are currently not supported by bare-process such as `process.getuid()`, `process.getgid()`, `process.getgroup()` 

This change switches the which dependency to bare-which as it is cross compatible with bare and node and uses fs.constants.X_OK to check for executability on posix-based systems instead of using the unsupported the functions above.