### PR TITLE
Add support for stdio option and return child process instance in configure and build

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -35,7 +35,7 @@ exports.cmake = function (opts = {}) {
 
   if (verbose) args.push('--verbose')
 
-  spawn(cmake(), args, opts)
+  return spawn(cmake(), args, opts)
 }
 
 exports.gradle = function (opts = {}) {
@@ -43,5 +43,5 @@ exports.gradle = function (opts = {}) {
     target = 'build'
   } = opts
 
-  spawn(gradle(), [target], opts)
+  return spawn(gradle(), [target], opts)
 }

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -153,7 +153,7 @@ module.exports = function configure (opts = {}) {
 
   for (const entry of define) args.push(`-D${entry}`)
 
-  spawn(cmake(), args, opts)
+  return spawn(cmake(), args, opts)
 }
 
 function supportsMultiConfiguration (generator) {

--- a/lib/shared/spawn.js
+++ b/lib/shared/spawn.js
@@ -8,7 +8,8 @@ module.exports = function spawn (cmd, args = [], opts = {}) {
     cwd = path.resolve('.'),
     detached = false,
     quiet = true,
-    verbose = false
+    verbose = false,
+    stdio = quiet ? 'ignore' : 'inherit'
   } = opts
 
   if (verbose) {
@@ -21,7 +22,7 @@ module.exports = function spawn (cmd, args = [], opts = {}) {
 
   if (detached) {
     proc = childProcess.spawn(cmd, args, {
-      stdio: 'ignore',
+      stdio,
       detached,
       env,
       cwd
@@ -30,7 +31,7 @@ module.exports = function spawn (cmd, args = [], opts = {}) {
     proc.unref()
   } else {
     proc = childProcess.spawnSync(cmd, args, {
-      stdio: quiet ? 'ignore' : 'inherit',
+      stdio,
       env,
       cwd
     })


### PR DESCRIPTION
This is for use in the [pear build PR](https://github.com/holepunchto/pear/pull/98) which runs the process in detached mode (using spawnSync blocks the pear process) and has a handler for stdio and stderr.